### PR TITLE
Use omnibus docker image for concourse tasks.

### DIFF
--- a/ci/create-db.yml
+++ b/ci/create-db.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/cf-cli
+    repository: 18fgsa/concourse-task
 
 inputs:
 - name: broker-src

--- a/ci/update-broker.yml
+++ b/ci/update-broker.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/cf-cli
+    repository: 18fgsa/concourse-task
 
 inputs:
 - name: broker-src


### PR DESCRIPTION
The `governmentpaas/cf-cli` image recently switched to alpine, which means we don't have `bash` anymore. Switching images is quicker than switching scripts to `sh`.

@dlapiduz 