### PR TITLE
Bump and expose cdn timeout.

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -5,6 +5,7 @@ set -u
 
 # Set defaults
 TTL="${TTL:-60}"
+CDN_TIMEOUT="${CDN_TIMEOUT:-7200}"
 
 suffix="${RANDOM}"
 DOMAIN=$(printf "${DOMAIN}" "${suffix}")
@@ -63,7 +64,7 @@ aws route53 change-resource-record-sets \
   --change-batch file://./create-cname.json
 
 # Wait for provision to complete
-elapsed=3600
+elapsed="${CDN_TIMEOUT}"
 until [ "${elapsed}" -le 0 ]; do
   status=$(cf service "${SERVICE_INSTANCE_NAME}" | grep "^Status: ")
   if [[ "${status}" =~ "succeeded" ]]; then
@@ -81,7 +82,7 @@ if [ "${updated}" != "true" ]; then
   exit 1
 fi
 
-elapsed=3600
+elapsed="${CDN_TIMEOUT}"
 until [ "${elapsed}" -le 0 ]; do
   if cdn_resp=$(curl "https://${DOMAIN}"); then
     break
@@ -127,7 +128,7 @@ aws route53 change-resource-record-sets \
 cf delete-service -f "${SERVICE_INSTANCE_NAME}"
 
 # Wait for deprovision to complete
-elapsed=3600
+elapsed="${CDN_TIMEOUT}"
 until [ "${elapsed}" -le 0 ]; do
   if cf service "${SERVICE_INSTANCE_NAME}" | grep "not found"; then
     deleted="true"

--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -32,6 +32,8 @@ hosted-zone-id-production:
 origin-url-production:
 domain-url-production:
 
+cdn-timeout:
+
 cf-api-url-staging: https://api.cloud.gov
 cf-deploy-username-staging:
 cf-deploy-password-staging:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -88,6 +88,7 @@ jobs:
       HOSTED_ZONE_ID: {{hosted-zone-id-staging}}
       ORIGIN: {{origin-url-staging}}
       DOMAIN: {{domain-url-staging}}
+      CDN_TIMEOUT: {{cdn-timeout}}
 
 - name: push-cf-cdn-service-broker-production
   plan:
@@ -168,6 +169,7 @@ jobs:
       HOSTED_ZONE_ID: {{hosted-zone-id-production}}
       ORIGIN: {{origin-url-production}}
       DOMAIN: {{domain-url-production}}
+      CDN_TIMEOUT: {{cdn-timeout}}
 
 resources:
 - name: broker-src


### PR DESCRIPTION
Because apparently cloudfront can take over an hour to deprovision.