### PR TITLE
Adjust metadata description

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,18 +1,18 @@
 {
   "id": "8478b533-2b59-4007-8494-2feec5970f94",
   "name": "cdn-route",
-  "description": "Custom URL, CDN, and free TLS certificates",
+  "description": "Custom domain, CDN caching, and TLS certificates",
   "bindable": true,
   "metadata": {
-    "displayName": "Content Distribution Network",
-    "documentationUrl": "https://cloud.gov/docs/services/cdn-route"
+    "displayName": "CDN Route",
+    "documentationUrl": "https://cloud.gov/docs/services/cdn-route/"
   },
   "plan_updateable": true,
   "plans": [
     {
       "id": "fc055c72-1075-44c9-9aee-bddd52e1b053",
       "name": "cdn-route",
-      "description": "A CDN distribution with custom URL and free TLS certificate with auto renewal",
+      "description": "A route service providing custom domains, CDN caching, and TLS certificates with auto renewal",
       "free": true,
       "metadata": {
         "displayName": "Content Distribution Network Route"

--- a/catalog.json
+++ b/catalog.json
@@ -1,7 +1,7 @@
 {
   "id": "8478b533-2b59-4007-8494-2feec5970f94",
   "name": "cdn-route",
-  "description": "Custom domain, CDN caching, and TLS certificates",
+  "description": "Custom domains, CDN caching, and TLS certificates",
   "bindable": true,
   "metadata": {
     "displayName": "CDN Route",
@@ -12,7 +12,7 @@
     {
       "id": "fc055c72-1075-44c9-9aee-bddd52e1b053",
       "name": "cdn-route",
-      "description": "A route service providing custom domains, CDN caching, and TLS certificates with auto renewal",
+      "description": "A service providing custom domains, CDN caching, and TLS certificates with auto renewal",
       "free": true,
       "metadata": {
         "displayName": "Content Distribution Network Route"


### PR DESCRIPTION
This is a followup on https://github.com/18F/cf-cdn-service-broker/pull/56 with a few edits to hopefully explain the service a bit more clearly. This goes along with https://github.com/18F/cg-site/pull/684 which updates the relevant docs page as well.

I'm not entirely sure these are the right edits for this metadata, since I don't know which field matches which part of the page, so feel free to correct/comment.

cc @msecret @thisisdano 