### PR TITLE
Set reasonable memory limit.

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -1,5 +1,6 @@
 ---
 buildpack: go_buildpack
+memory: 128M
 services:
 - rds-cdn-broker
 env:


### PR DESCRIPTION
I think this should be enough:

```
± cf app cdn-broker
Showing health and status for app cdn-broker in org cloud-gov / space services as joshua.carp@gsa.gov...
OK

requested state: started
instances: 1/1
usage: 512M x 1 instances
urls: cdn-broker.fr.cloud.gov
last uploaded: Fri Jan 27 22:27:42 UTC 2017
stack: cflinuxfs2
buildpack: go_buildpack

     state     since                    cpu    memory          disk          details
#0   running   2017-01-27 05:28:55 PM   0.0%   15.9M of 512M   87.3M of 1G
```