### PR TITLE
Decouple deleting old certificates from the renewal process

### DIFF
--- a/cmd/cdn-cron/main.go
+++ b/cmd/cdn-cron/main.go
@@ -48,6 +48,11 @@ func main() {
 		manager.RenewAll()
 	})
 
+	c.AddFunc(settings.Schedule, func() {
+		logger.Info("Running cert cleanup")
+		manager.DeleteOrphanedCerts()
+	})
+
 	logger.Info("Starting cron")
 	c.Start()
 

--- a/models/mocks/RouteManagerIface.go
+++ b/models/mocks/RouteManagerIface.go
@@ -101,6 +101,11 @@ func (_m *RouteManagerIface) RenewAll() {
 	_m.Called()
 }
 
+// DeleteOrphanedCerts provides a mock function with given fields:
+func (_m *RouteManagerIface) DeleteOrphanedCerts() {
+	_m.Called()
+}
+
 // Update provides a mock function with given fields: instanceId, domain, origin, path, insecureOrigin, forwardedHeaders
 func (_m *RouteManagerIface) Update(instanceId string, domain string, origin string, path string, insecureOrigin bool, forwardedHeaders []string, forwardCookies bool) error {
 	ret := _m.Called(instanceId, domain, origin, path, insecureOrigin, forwardedHeaders)

--- a/models/models.go
+++ b/models/models.go
@@ -391,7 +391,9 @@ func (m *RouteManager) deployCertificate(instanceId, distId string, cert acme.Ce
 		return err
 	}
 
-	name := fmt.Sprintf("cdn-route-%s-%s", instanceId, expires)
+	name := fmt.Sprintf("cdn-route-%s-%s", instanceId, expires.Format("2006-01-02_15-04-05"))
+
+	m.Logger.Info("Uploading certificate to IAM", lager.Data{"name": name})
 
 	certId, err := m.Iam.UploadCertificate(name, cert)
 	if err != nil {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -1,0 +1,152 @@
+package models_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+	"github.com/18F/cf-cdn-service-broker/models"
+	"github.com/18F/cf-cdn-service-broker/utils"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/xenolf/lego/acme"
+)
+
+type MockUtilsIam struct {
+	mock.Mock
+
+	Settings config.Settings
+	Service  *iam.IAM
+}
+
+// test doesn't execute this method
+func (_f MockUtilsIam) UploadCertificate(name string, cert acme.CertificateResource) (string, error) {
+	return "", nil
+}
+
+// don't mock this method
+func (_f MockUtilsIam) ListCertificates(callback func(iam.ServerCertificateMetadata) bool) error {
+	orig := &utils.Iam{Settings: _f.Settings, Service: _f.Service}
+	return orig.ListCertificates(callback)
+}
+
+func (_f MockUtilsIam) DeleteCertificate(certName string) error {
+	args := _f.Called(certName)
+	return args.Error(0)
+}
+
+func TestDeleteOrphanedCerts(t *testing.T) {
+	logger := lager.NewLogger("cdn-cron-test")
+	logger.RegisterSink(lager.NewWriterSink(os.Stderr, lager.INFO))
+
+	settings, _ := config.NewSettings()
+	session := session.New(nil)
+
+	//mock out the aws call to return a fixed list of certs, two of which should be deleted
+	fakeiam := iam.New(session)
+	fakeiam.Handlers.Clear()
+	fakeiam.Handlers.Send.PushBack(func(r *request.Request) {
+		//t.Log(r.Operation.Name)
+		switch r.Operation.Name {
+		case "ListServerCertificates":
+			old := time.Now().AddDate(0, 0, -2)
+			current := time.Now().AddDate(0, 0, 0)
+
+			list := []*iam.ServerCertificateMetadata{
+				&iam.ServerCertificateMetadata{
+					Arn: aws.String("an-active-certificate"),
+					ServerCertificateName: aws.String("an-active-certificate"),
+					ServerCertificateId:   aws.String("an-active-certificate"),
+					UploadDate:            &old,
+				},
+				&iam.ServerCertificateMetadata{
+					Arn: aws.String("some-other-active-certificate"),
+					ServerCertificateName: aws.String("some-other-active-certificate"),
+					ServerCertificateId:   aws.String("some-other-active-certificate"),
+					UploadDate:            &old,
+				},
+				&iam.ServerCertificateMetadata{
+					Arn: aws.String("orphaned-but-not-old-enough"),
+					ServerCertificateName: aws.String("orphaned-but-not-old-enough"),
+					ServerCertificateId:   aws.String("this-cert-should-not-be-deleted"),
+					UploadDate:            &current,
+				},
+				&iam.ServerCertificateMetadata{
+					Arn: aws.String("some-orphaned-cert"),
+					ServerCertificateName: aws.String("some-orphaned-cert"),
+					ServerCertificateId:   aws.String("this-cert-should-be-deleted"),
+					UploadDate:            &old,
+				},
+				&iam.ServerCertificateMetadata{
+					Arn: aws.String("some-other-orphaned-cert"),
+					ServerCertificateName: aws.String("some-other-orphaned-cert"),
+					ServerCertificateId:   aws.String("this-cert-should-also-be-deleted"),
+					UploadDate:            &old,
+				},
+			}
+			data := r.Data.(*iam.ListServerCertificatesOutput)
+			data.IsTruncated = aws.Bool(false)
+			data.ServerCertificateMetadataList = list
+		}
+	})
+
+	//mock out the aws call to return a fixed list of distributions
+	fakecf := cloudfront.New(session)
+	fakecf.Handlers.Clear()
+	fakecf.Handlers.Send.PushBack(func(r *request.Request) {
+		//t.Log(r.Operation.Name)
+		switch r.Operation.Name {
+		case "ListDistributions2016_11_25":
+			list := []*cloudfront.DistributionSummary{
+				&cloudfront.DistributionSummary{
+					ARN: aws.String("some-distribution"),
+					ViewerCertificate: &cloudfront.ViewerCertificate{
+						IAMCertificateId: aws.String("an-active-certificate"),
+					},
+				},
+				&cloudfront.DistributionSummary{
+					ARN: aws.String("some-other-distribution"),
+					ViewerCertificate: &cloudfront.ViewerCertificate{
+						IAMCertificateId: aws.String("some-other-active-certificate"),
+					},
+				},
+			}
+
+			data := r.Data.(*cloudfront.ListDistributionsOutput)
+			data.DistributionList = &cloudfront.DistributionList{
+				IsTruncated: aws.Bool(false),
+				Items:       list,
+			}
+		}
+	})
+
+	mui := new(MockUtilsIam)
+	mui.Settings = settings
+	mui.Service = fakeiam
+
+	// expect the orphaned certs to be deleted
+	mui.On("DeleteCertificate", "some-orphaned-cert").Return(nil)
+	mui.On("DeleteCertificate", "some-other-orphaned-cert").Return(nil)
+
+	m := models.RouteManager{
+		Logger:     logger,
+		Iam:        mui,
+		CloudFront: &utils.Distribution{settings, fakecf},
+	}
+
+	//run the test
+	m.DeleteOrphanedCerts()
+
+	//check our expectations
+	mui.AssertExpectations(t)
+
+}


### PR DESCRIPTION
This PR changes the CDN broker so that the process of deleting old certificates is not linked to the renewal process.  The broker now uses the service instance id and the expiration date of the certificate to generate a unique name when uploading a cert rather than the `-new` suffix.

A separate process prunes old certificates, removing any certificates under the configured `IamPathPrefix` that are not associated with a distribution and are older than 24 hours.  The time check is intended to prevent accidental pruning of newly uploaded certificates that haven't been associated with a distribution yet.

When testing this in staging, it correctly identified and removed an existing orphaned cert:

	2017-04-06T18:00:01.68-0700 [APP/PROC/WEB/0]ERR {"timestamp":"1491526801.685461521","source":"cdn-cron","message":"cdn-cron.Deleting orphaned certificate","log_level":1,"data":{"cert":{"Arn":"arn:aws:iam::699351240001:server-certificate/cloudfront/cg-staging/cdn-route-staging-07.cdn-broker-test.cloud.gov-new","Expiration":"2017-03-29T21:10:00Z","Path":"/cloudfront/cg-staging/","ServerCertificateId":"ASCAJIPQPBDA4VJSXBUZE","ServerCertificateName":"cdn-route-staging-07.cdn-broker-test.cloud.gov-new","UploadDate":"2016-12-29T22:09:37Z"}}}
	2017-04-06T19:00:00.02-0700 [APP/PROC/WEB/0]ERR {"timestamp":"1491530400.006797791","source":"cdn-cron","message":"cdn-cron.Running renew","log_level":1,"data":{}}
	2017-04-06T19:00:00.03-0700 [APP/PROC/WEB/0]ERR {"timestamp":"1491530400.029762506","source":"cdn-cron","message":"cdn-cron.Running cert cleanup","log_level":1,"data":{}}
