### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/cmd/cdn-broker/main.go
+++ b/cmd/cdn-broker/main.go
@@ -89,7 +89,16 @@ func main() {
 		Password: settings.BrokerPassword,
 	}
 
+	server := buildHTTPHandler(broker, logger, credentials)
+	http.ListenAndServe(fmt.Sprintf(":%s", settings.Port), server)
+}
+
+func buildHTTPHandler(broker *broker.CdnServiceBroker, logger lager.Logger, credentials brokerapi.BrokerCredentials) http.Handler {
 	brokerAPI := brokerapi.New(broker, logger, credentials)
-	http.Handle("/", brokerAPI)
-	http.ListenAndServe(fmt.Sprintf(":%s", settings.Port), nil)
+	mux := http.NewServeMux()
+	mux.Handle("/", brokerAPI)
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
 }

--- a/cmd/cdn-broker/main_test.go
+++ b/cmd/cdn-broker/main_test.go
@@ -16,7 +16,7 @@ func TestBuildHTTPHandler(t *testing.T) {
 		lager.NewLogger("main.test"),
 		brokerapi.BrokerCredentials{},
 	)
-	req, err := http.NewRequest("GET", "http://example.com/healthcheck", nil)
+	req, err := http.NewRequest("GET", "http://example.com/healthcheck/http", nil)
 	if err != nil {
 		t.Error("Building new HTTP request: error should not have occurred")
 	}

--- a/cmd/cdn-broker/main_test.go
+++ b/cmd/cdn-broker/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/18F/cf-cdn-service-broker/broker"
+	"github.com/pivotal-cf/brokerapi"
+)
+
+func TestBuildHTTPHandler(t *testing.T) {
+	handler := buildHTTPHandler(
+		&broker.CdnServiceBroker{},
+		lager.NewLogger("main.test"),
+		brokerapi.BrokerCredentials{},
+	)
+	req, err := http.NewRequest("GET", "http://example.com/healthcheck", nil)
+	if err != nil {
+		t.Error("Building new HTTP request: error should not have occurred")
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("HTTP response: response code was %d, expecting 200", w.Code)
+	}
+}

--- a/cmd/cdn-broker/main_test.go
+++ b/cmd/cdn-broker/main_test.go
@@ -7,15 +7,17 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/18F/cf-cdn-service-broker/broker"
+	"github.com/18F/cf-cdn-service-broker/config"
 	"github.com/pivotal-cf/brokerapi"
 )
 
-func TestBuildHTTPHandler(t *testing.T) {
-	handler := buildHTTPHandler(
+func TestHTTPHandler(t *testing.T) {
+	brokerAPI := brokerapi.New(
 		&broker.CdnServiceBroker{},
 		lager.NewLogger("main.test"),
 		brokerapi.BrokerCredentials{},
 	)
+	handler := bindHTTPHandlers(brokerAPI, config.Settings{})
 	req, err := http.NewRequest("GET", "http://example.com/healthcheck/http", nil)
 	if err != nil {
 		t.Error("Building new HTTP request: error should not have occurred")

--- a/glide.lock
+++ b/glide.lock
@@ -34,7 +34,7 @@ imports:
   - service/s3
   - service/sts
 - name: github.com/cloudfoundry-community/go-cfclient
-  version: 519c9eb6445d32120dfaf3659668e3b7032ea415
+  version: 23156ed0e73babdbde160007042a4a4e35aec8d1
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:

--- a/healthchecks/cloudfoundry.go
+++ b/healthchecks/cloudfoundry.go
@@ -1,0 +1,28 @@
+package healthchecks
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Cloudfoundry(settings config.Settings) error {
+	// We're only validating that the CF endpoint is contactable here, as
+	// testing the authentication is tricky
+	_, err := cfclient.NewClient(&cfclient.Config{
+		ApiAddress:   settings.APIAddress,
+		ClientID:     settings.ClientID,
+		ClientSecret: settings.ClientSecret,
+		HttpClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/cloudfront.go
+++ b/healthchecks/cloudfront.go
@@ -1,0 +1,22 @@
+package healthchecks
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Cloudfront(settings config.Settings) error {
+	session := session.New(aws.NewConfig().WithRegion(settings.AwsDefaultRegion))
+	svc := cloudfront.New(session)
+
+	params := &cloudfront.ListDistributionsInput{}
+	_, err := svc.ListDistributions(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/healthchecks.go
+++ b/healthchecks/healthchecks.go
@@ -1,0 +1,49 @@
+package healthchecks
+
+import (
+	"fmt"
+	"github.com/18F/cf-cdn-service-broker/config"
+	"net/http"
+)
+
+var checks = map[string]func(config.Settings) error{
+	"letsencrypt":  LetsEncrypt,
+	"s3":           S3,
+	"cloudfront":   Cloudfront,
+	"cloudfoundry": Cloudfoundry,
+	"postgresql":   Postgresql,
+}
+
+func Bind(mux *http.ServeMux, settings config.Settings) {
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		body := ""
+		for name, function := range checks {
+			err := function(settings)
+			if err != nil {
+				body = body + fmt.Sprintf("%s error: %s\n", name, err)
+			}
+		}
+		if body != "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "%s", body)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	mux.HandleFunc("/healthcheck/http", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for name, function := range checks {
+		mux.HandleFunc("/healthcheck/"+name, func(w http.ResponseWriter, r *http.Request) {
+			err := function(settings)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "%s error: %s", name, err)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+	}
+}

--- a/healthchecks/letsencrypt.go
+++ b/healthchecks/letsencrypt.go
@@ -1,0 +1,32 @@
+package healthchecks
+
+import (
+	"crypto"
+	"github.com/xenolf/lego/acme"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+type User struct {
+	Email        string
+	Registration *acme.RegistrationResource
+	key          crypto.PrivateKey
+}
+
+func (u *User) GetEmail() string {
+	return u.Email
+}
+
+func (u *User) GetRegistration() *acme.RegistrationResource {
+	return u.Registration
+}
+
+func (u *User) GetPrivateKey() crypto.PrivateKey {
+	return u.key
+}
+
+func LetsEncrypt(settings config.Settings) error {
+	user := &User{key: "cheese"}
+	_, err := acme.NewClient("https://acme-v01.api.letsencrypt.org/directory", user, acme.RSA2048)
+	return err
+}

--- a/healthchecks/postgresql.go
+++ b/healthchecks/postgresql.go
@@ -1,0 +1,19 @@
+package healthchecks
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func Postgresql(settings config.Settings) error {
+	db, err := gorm.Open("postgres", settings.DatabaseUrl)
+	defer db.Close()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/healthchecks/s3.go
+++ b/healthchecks/s3.go
@@ -1,0 +1,40 @@
+package healthchecks
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/18F/cf-cdn-service-broker/config"
+)
+
+func S3(settings config.Settings) error {
+	bucket := settings.Bucket
+	key := "healthcheck-test-key"
+
+	session := session.New(aws.NewConfig().WithRegion(settings.AwsDefaultRegion))
+	svc := s3.New(session)
+
+	input := s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   strings.NewReader("cheese"),
+	}
+
+	_, err := svc.PutObject(&input)
+	if err != nil {
+		return err
+	}
+
+	_, err = svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/apps.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/apps.go
@@ -324,3 +324,23 @@ func (c *Client) AppByGuid(guid string) (App, error) {
 	appResource.Entity.c = c
 	return appResource.Entity, nil
 }
+
+//AppByName takes an appName, and GUIDs for a space and org, and performs
+// the API lookup with those query parameters set to return you the desired
+// App object.
+func (c *Client) AppByName(appName, spaceGuid, orgGuid string) (app App, err error) {
+	query := url.Values{}
+	query.Add("q", fmt.Sprintf("organization_guid:%s", orgGuid))
+	query.Add("q", fmt.Sprintf("space_guid:%s", spaceGuid))
+	query.Add("q", fmt.Sprintf("name:%s", appName))
+	apps, err := c.ListAppsByQuery(query)
+	if err != nil {
+		return
+	}
+	if len(apps) == 0 {
+		err = fmt.Errorf("No app found with name: `%s` in space with GUID `%s` and org with GUID `%s`", appName, spaceGuid, orgGuid)
+		return
+	}
+	app = apps[0]
+	return
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/client.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/client.go
@@ -267,6 +267,9 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	}
 
 	resp, err := c.config.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		cfErr := &CloudFoundryErrors{}
@@ -276,7 +279,7 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 		return nil, cfErr
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 // toHTTP converts the request to an HTTP request

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/client_test.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/client_test.go
@@ -40,6 +40,26 @@ func TestMakeRequest(t *testing.T) {
 	})
 }
 
+func TestMakeRequestFailure(t *testing.T) {
+	Convey("Test making request b", t, func() {
+		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)
+		defer teardown()
+		c := &Config{
+			ApiAddress:        server.URL,
+			Username:          "foo",
+			Password:          "bar",
+			SkipSslValidation: true,
+		}
+		client, err := NewClient(c)
+		So(err, ShouldBeNil)
+		req := client.NewRequest("GET", "/v2/organizations")
+		req.url = "%gh&%ij"
+		resp, err := client.DoRequest(req)
+		So(resp, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+}
+
 func TestMakeRequestWithTimeout(t *testing.T) {
 	Convey("Test making request b", t, func() {
 		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload, "", 200, "", nil}, t)

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/spaces.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/spaces.go
@@ -306,18 +306,17 @@ func (c *Client) fetchSpaces(requestUrl string) ([]Space, error) {
 	return spaces, nil
 }
 
-func (c *Client) GetSpaceByName(spaceName string, orgGuid string) (Space, error) {
-	var space Space
-	q := url.Values{}
-	q.Set("q", "organization_guid:"+orgGuid)
-	q.Set("&q", "name:"+spaceName)
-	spaces, err := c.ListSpacesByQuery(q)
+func (c *Client) GetSpaceByName(spaceName string, orgGuid string) (space Space, err error) {
+	query := url.Values{}
+	query.Add("q", fmt.Sprintf("organization_guid:%s", orgGuid))
+	query.Add("q", fmt.Sprintf("name:%s", spaceName))
+	spaces, err := c.ListSpacesByQuery(query)
 	if err != nil {
-		return space, err
+		return
 	}
 
 	if len(spaces) == 0 {
-		return space, fmt.Errorf("Unable to find space %s", spaceName)
+		return space, fmt.Errorf("No space found with name: `%s` in org with GUID: `%s`", spaceName, orgGuid)
 	}
 
 	return spaces[0], nil


### PR DESCRIPTION
## What

Add a simple healthcheck endpoint. We deploy the CDN broker on its own VM and access it via an ELB. This endpoint is used by the ELB to check if the app is running. It should not be protected by the basic auth.

Also, the cfclient library is updated to avoid annoying crashes.

## How to review

* `cd cdm/cdn-broker && go test`
* Deploy
* Access `/healthcheck`, it should return `HTTP 200 OK`
