### PR TITLE
Prevent failed challenges from creating orphaned distributions.

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -229,8 +229,8 @@ func (m *RouteManager) Create(instanceId, domain, origin, path string, insecureO
 	route.DistId = *dist.Id
 
 	if err := m.db.Create(route).Error; err != nil {
-        return nil, err
-    }
+		return nil, err
+	}
 
 	return route, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -216,6 +216,10 @@ func (m *RouteManager) Create(instanceId, domain, origin, path string, insecureO
 		InsecureOrigin: insecureOrigin,
 	}
 
+	if err := m.ensureChallenges(route, false); err != nil {
+		return nil, err
+	}
+
 	dist, err := m.cloudFront.Create(instanceId, route.GetDomains(), origin, path, insecureOrigin, forwardedHeaders, forwardCookies, tags)
 	if err != nil {
 		return nil, err
@@ -224,11 +228,10 @@ func (m *RouteManager) Create(instanceId, domain, origin, path string, insecureO
 	route.DomainInternal = *dist.DomainName
 	route.DistId = *dist.Id
 
-	if err := m.ensureChallenges(route, false); err != nil {
-		return nil, err
-	}
+	if err := m.db.Create(route).Error; err != nil {
+        return nil, err
+    }
 
-	m.db.Create(route)
 	return route, nil
 }
 


### PR DESCRIPTION
Prior to this change, we create cloudfront distributions before acme challenges.
If creating acme challenges fails, we're left with an orphaned cloudfront
distribution that the broker isn't aware of. This patch gets the acme challenges
first to avoid this confusing state.