### PR TITLE
Debug potential dns caching.

### DIFF
--- a/utils/certs.go
+++ b/utils/certs.go
@@ -55,12 +55,6 @@ func (u *User) SetPrivateKey(key crypto.PrivateKey) {
 	u.key = key
 }
 
-var insecureClient = &http.Client{
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	},
-}
-
 type HTTPProvider struct {
 	Settings config.Settings
 	Service  *s3.S3
@@ -77,6 +71,12 @@ func (p *HTTPProvider) Present(domain, token, keyAuth string) error {
 	}
 	if _, err := p.Service.PutObject(&input); err != nil {
 		return err
+	}
+
+	insecureClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
 	}
 
 	return acme.WaitFor(10*time.Second, 2*time.Second, func() (bool, error) {


### PR DESCRIPTION
It looks like our http challenge pre-check can cache dns lookups. Specifically, if a user migrates an existing domain to this broker, the pre-check seems to get stuck on the previous address long after dns has been updated, and can only be fixed by restarting the broker. For reasons I frankly don't understand, creating the http client once per pre-check instead of at the module level fixes this, which I verified by creating a few stuck instances before deploying this change and a few successful instances afterwards.

This should resolve an issue that @wslack ran into a few times such that moving a domain from the east client elb for 18f.gov to govcloud would get stuck and require talking to support.