### PR TITLE
fix race condition in acc tests

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -133,7 +133,7 @@ fi
 cat << EOF > "${path}/app/manifest.yml"
 ---
 applications:
-- name: cdn-broker-test
+- name: cdn-broker-test-${CHALLENGE_TYPE}
   buildpack: staticfile_buildpack
   domain: ${DOMAIN}
   no-hostname: true


### PR DESCRIPTION
This fixes what I believe is a [race condition](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cdn-broker/jobs/acceptance-tests-production/builds/28) between the DNS and HTTP challenge tests when they are run in parallel.

This condition can occur when the tests are only seconds behind each other, which can cause the test app to be in a staging state when the second app attempts a `cf push`.  This will cause a [VCAP::CloudController::BuildCreate::StagingInProgress](https://github.com/cloudfoundry/cloud_controller_ng/blob/faa8a762a0ac84383a7a6d1735a72d9cc3616413/spec/unit/actions/build_create_spec.rb#L257-L265) error and fail the test.

