### PR TITLE
Restore TLS 1 and deprecate DES cipher.

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -136,8 +136,9 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					HTTPSPort:            aws.Int64(443),
 					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
-						Quantity: aws.Int64(2),
+						Quantity: aws.Int64(3),
 						Items: []*string{
+							aws.String("TLSv1.0"),
 							aws.String("TLSv1.1"),
 							aws.String("TLSv1.2"),
 						},
@@ -274,7 +275,7 @@ func (d *Distribution) SetCertificate(distId, certId string) error {
 	DistributionConfig.ViewerCertificate.IAMCertificateId = aws.String(certId)
 	DistributionConfig.ViewerCertificate.CertificateSource = aws.String("iam")
 	DistributionConfig.ViewerCertificate.SSLSupportMethod = aws.String("sni-only")
-	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1.1_2016")
+	DistributionConfig.ViewerCertificate.MinimumProtocolVersion = aws.String("TLSv1_2016")
 	DistributionConfig.ViewerCertificate.CloudFrontDefaultCertificate = aws.Bool(false)
 
 	_, err = d.Service.UpdateDistribution(&cloudfront.UpdateDistributionInput{


### PR DESCRIPTION
We should drop tls 1.0 (and probably 1.1) soon, but need to look into usage and write customer comms first. For now, restore tls 1.0, but drop support for DES-CBC3-SHA by using tlsv1_2016 instead of the original tlsv1.

h/t @konklone 