### PR TITLE
Revert tls config again.

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -138,7 +138,7 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
 						Quantity: aws.Int64(3),
 						Items: []*string{
-							aws.String("TLSv1.0"),
+							aws.String("TLSv1"),
 							aws.String("TLSv1.1"),
 							aws.String("TLSv1.2"),
 						},


### PR DESCRIPTION
Fixes this:

```
1 validation error detected: Value '[TLSv1.0, TLSv1.1, TLSv1.2]' at 'distributionConfigWithTags.distributionConfig.origins.items.1.member.customOriginConfig.originSslProtocols.items' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [SSLv3, TLSv1, TLSv1.1, TLSv1.2]]
```

😅 