### PR TITLE
Set origin read timeout to default.

### DIFF
--- a/utils/cloudfront.go
+++ b/utils/cloudfront.go
@@ -134,6 +134,7 @@ func (d *Distribution) fillDistributionConfig(config *cloudfront.DistributionCon
 				CustomOriginConfig: &cloudfront.CustomOriginConfig{
 					HTTPPort:             aws.Int64(80),
 					HTTPSPort:            aws.Int64(443),
+					OriginReadTimeout:    aws.Int64(30),
 					OriginProtocolPolicy: getOriginProtocolPolicy(insecureOrigin),
 					OriginSslProtocols: &cloudfront.OriginSslProtocols{
 						Quantity: aws.Int64(3),


### PR DESCRIPTION
CloudFront now requires setting origin read timeout on updates.