### PR TITLE
Optionally set cacert during acceptance tests.

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -12,6 +12,12 @@ suffix="${RANDOM}"
 DOMAIN=$(printf "${DOMAIN}" "${suffix}")
 SERVICE_INSTANCE_NAME=$(printf "${SERVICE_INSTANCE_NAME}" "${suffix}")
 
+curl_args=()
+if [ -n "${CA_CERT:-}" ]; then
+  echo "${CA_CERT}" > ca.pem
+  curl_args=("--cacert" "ca.pem")
+fi
+
 path="$(dirname $0)"
 
 # Authenticate
@@ -147,7 +153,7 @@ cf push -f "${path}/app/manifest.yml" -p "${path}/app"
 # Assert expected response from cdn
 elapsed="${CDN_TIMEOUT}"
 until [ "${elapsed}" -le 0 ]; do
-  if curl "https://${DOMAIN}" | grep "CDN Broker Test"; then
+  if curl "${curl_args[@]}" "https://${DOMAIN}" | grep "CDN Broker Test"; then
     break
   fi
   let elapsed-=60

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -94,6 +94,7 @@ jobs:
         HOSTED_ZONE_ID: {{hosted-zone-id-staging}}
         DOMAIN: {{domain-url-staging}}
         CDN_TIMEOUT: {{cdn-timeout}}
+        CA_CERT: {{acceptance-test-ca-cert-staging}}
     - task: acceptance-tests-dns-01
       file: broker-src/ci/acceptance-tests.yml
       params:
@@ -187,6 +188,7 @@ jobs:
         HOSTED_ZONE_ID: {{hosted-zone-id-production}}
         DOMAIN: {{domain-url-production}}
         CDN_TIMEOUT: {{cdn-timeout}}
+        CA_CERT: {{acceptance-test-ca-cert-production}}
     - task: acceptance-tests-dns-01
       file: broker-src/ci/acceptance-tests.yml
       params:


### PR DESCRIPTION
So that we can test staging against the staging let's encrypt service.