### PR TITLE
Update cnames after getting certs (for Update and Create)

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -286,6 +286,11 @@ func (m *RouteManager) Update(instanceId, domain, origin string, path string, in
 		return err
 	}
 
+	// When we update the CloudFront distribution we should use the old domains
+	// until we have a valid certificate in IAM.
+	// CloudFront gets updated when we receive new certificates during Poll
+	oldDomainsForCloudFront := route.GetDomains()
+
 	// Override any settings that are new or different.
 	if domain != "" {
 		route.DomainExternal = domain
@@ -301,7 +306,7 @@ func (m *RouteManager) Update(instanceId, domain, origin string, path string, in
 	}
 
 	// Update the distribution
-	dist, err := m.cloudFront.Update(route.DistId, route.GetDomains(),
+	dist, err := m.cloudFront.Update(route.DistId, oldDomainsForCloudFront,
 		route.Origin, route.Path, route.InsecureOrigin, forwardedHeaders, forwardCookies)
 	if err != nil {
 		return err


### PR DESCRIPTION
Myself and @46bit took #116 and applied it to GDS's fork alphagov/paas-cdn-broker but @46bit found that `Update` was broken for the same reason as `Create` pre-fix.

This PR is the code-change in #116, plus an additional commit which uses the old domains when updating Cloudfront in `Update`, and relies on `deployCertificate` to do the actual certificate and CNAME changes.

Please let us know if we need to sign a CLA, alternatively feel free to ignore/close this PR.

[Context](https://github.com/alphagov/paas-cdn-broker/pull/13)