### PR TITLE
Drop http-01 tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,25 +81,20 @@ jobs:
     passed: [push-cf-cdn-service-broker-staging]
     trigger: true
   - aggregate:
-    - task: acceptance-tests-http-01
+    - task: acceptance-tests-dns-01
       file: broker-src/ci/acceptance-tests.yml
       params: &acceptance-tests-params-staging
         <<: *cf-creds-staging
         SERVICE_NAME: cdn-route
         PLAN_NAME: cdn-route
         SERVICE_INSTANCE_NAME: cdn-acceptance-test-%s
-        CHALLENGE_TYPE: HTTP-01
+        CHALLENGE_TYPE: DNS-01
         AWS_ACCESS_KEY_ID: {{cdn-broker-access-key-id-staging}}
         AWS_SECRET_ACCESS_KEY: {{cdn-broker-secret-access-key-staging}}
         HOSTED_ZONE_ID: {{hosted-zone-id-staging}}
         DOMAIN: {{domain-url-staging}}
         CDN_TIMEOUT: {{cdn-timeout}}
         CA_CERT: {{acceptance-test-ca-cert-staging}}
-    - task: acceptance-tests-dns-01
-      file: broker-src/ci/acceptance-tests.yml
-      params:
-        <<: *acceptance-tests-params-staging
-        CHALLENGE_TYPE: DNS-01
 
 - name: push-cf-cdn-service-broker-production
   plan:
@@ -175,25 +170,20 @@ jobs:
     passed: [push-cf-cdn-service-broker-production]
     trigger: true
   - aggregate:
-    - task: acceptance-tests-http-01
+    - task: acceptance-tests-dns-01
       file: broker-src/ci/acceptance-tests.yml
       params: &acceptance-tests-params-production
         <<: *cf-creds-production
         SERVICE_NAME: cdn-route
         PLAN_NAME: cdn-route
+        CHALLENGE_TYPE: DNS-01
         SERVICE_INSTANCE_NAME: cdn-acceptance-test-%s
-        CHALLENGE_TYPE: HTTP-01
         AWS_ACCESS_KEY_ID: {{cdn-broker-access-key-id-production}}
         AWS_SECRET_ACCESS_KEY: {{cdn-broker-secret-access-key-production}}
         HOSTED_ZONE_ID: {{hosted-zone-id-production}}
         DOMAIN: {{domain-url-production}}
         CDN_TIMEOUT: {{cdn-timeout}}
         CA_CERT: {{acceptance-test-ca-cert-production}}
-    - task: acceptance-tests-dns-01
-      file: broker-src/ci/acceptance-tests.yml
-      params:
-        <<: *acceptance-tests-params-production
-        CHALLENGE_TYPE: DNS-01
 
 resources:
 - name: broker-src


### PR DESCRIPTION
More fallout from CloudFront changing their API. HTTP01 tests no longer work because CloudFront responds to all requests with mismatched Host headers by sending a 403.

This only tears out the test so we can ship what we have - there's still work to be done to update docs and cli output to make it clear we don't support HTTP01