### PR TITLE
remove check on length of instructions vs number of domains

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -132,9 +132,6 @@ func (b *CdnServiceBroker) LastOperation(
 		if err != nil {
 			return brokerapi.LastOperation{}, err
 		}
-		if len(instructions) != len(route.GetDomains()) {
-			return brokerapi.LastOperation{}, fmt.Errorf("Expected to find %d tokens; found %d", len(route.GetDomains()), len(instructions))
-		}
 		description := fmt.Sprintf(
 			"Provisioning in progress [%s => %s]; CNAME or ALIAS domain %s to %s or create TXT record(s): \n%s",
 			route.DomainExternal, route.Origin, route.DomainExternal, route.DomainInternal,


### PR DESCRIPTION

## Changes proposed in this pull request:
- remove the assertion that the number of instructions is the same as the number of domains.
This check is invalid, for instance, when adding a new domain to an instance with an already-verified domain.

## security considerations
None