### PR TITLE
pause for a little bit between creating domain and service instance

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -28,6 +28,9 @@ cf target -o "${CF_ORGANIZATION}" -s "${CF_SPACE}"
 # Create private domain
 cf create-domain "${CF_ORGANIZATION}" "${DOMAIN}"
 
+# sleep a little to let the domain create
+sleep 5
+
 # Create service
 opts=$(jq -n --arg domain "${DOMAIN}" '{domain: $domain}')
 cf create-service "${SERVICE_NAME}" "${PLAN_NAME}" "${SERVICE_INSTANCE_NAME}" -c "${opts}"


### PR DESCRIPTION
## Changes proposed in this pull request:
- pause for 5 seconds between creating the domain and creating the service instance that needs it

## security considerations
none