### PR TITLE
add error logic for failed CloudFront update

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -149,6 +149,11 @@ func (b *CdnServiceBroker) LastOperation(
 				route.DomainExternal, route.Origin, route.DomainInternal,
 			),
 		}, nil
+	case models.Failed:
+		return brokerapi.LastOperation{
+			State: brokerapi.Failed,
+			Description: "Failure while provisioning instance",
+		}, nil
 	default:
 		return brokerapi.LastOperation{
 			State: brokerapi.Succeeded,

--- a/models/models.go
+++ b/models/models.go
@@ -40,6 +40,7 @@ const (
 	Provisioned          = "provisioned"
 	Deprovisioning       = "deprovisioning"
 	Deprovisioned        = "deprovisioned"
+	Failed               = "failed"
 )
 
 var (
@@ -704,6 +705,11 @@ func (m *RouteManager) updateProvisioning(r *Route) error {
 		}
 		if err := m.deployCertificate(*r, cert); err != nil {
 			lsession.Error("deploy-certificate", err)
+			r.State = Failed
+			if dbErr := m.db.Save(r).Error; dbErr != nil {
+				newErr := fmt.Errorf("error saving state to db: %s while processing error deployin certificate: %s", dbErr, err)
+				return newErr
+			}
 			return err
 		}
 

--- a/models/models.go
+++ b/models/models.go
@@ -707,7 +707,7 @@ func (m *RouteManager) updateProvisioning(r *Route) error {
 			lsession.Error("deploy-certificate", err)
 			r.State = Failed
 			if dbErr := m.db.Save(r).Error; dbErr != nil {
-				newErr := fmt.Errorf("error saving state to db: %s while processing error deployin certificate: %s", dbErr, err)
+				newErr := fmt.Errorf("error saving state to db: %s while processing error deploying certificate: %s", dbErr, err)
 				return newErr
 			}
 			return err


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a path for failed updates. Currently, we assume a service instance is either changing or successful, and have no way of reporting that it's failed
- Set service instance to failed when a failure happens while updating cloudfront after getting a certificate. this fixes 18F/cg-product#1083 

## security considerations
None - this just cleans up error handling
